### PR TITLE
added http/2 example

### DIFF
--- a/examples/http2/README.md
+++ b/examples/http2/README.md
@@ -1,0 +1,27 @@
+# HTTP/2 example
+
+Simple HTTP/2 server using `tinyhttp` and `http2` module.
+
+## Setup
+Generate the certificate key.
+
+```sh
+openssl req -x509 -newkey rsa:2048 -nodes -sha256 -subj '/CN=localhost' \
+  -keyout localhost-privkey.pem -out localhost-cert.pem
+```
+
+Install all dependencies
+```sh
+pnpm install
+```
+
+## Run
+```sh
+node index.js
+```
+
+and in another terminal:
+
+```sh
+curl https://localhost:3000 -kiv
+```

--- a/examples/http2/index.js
+++ b/examples/http2/index.js
@@ -1,0 +1,12 @@
+import { App } from '@tinyhttp/app'
+import fs from 'fs'
+import http2 from 'http2'
+
+const app = new App()
+
+const options = {
+  key: fs.readFileSync('localhost-privkey.pem'),
+  cert: fs.readFileSync('localhost-cert.pem'),
+}
+
+http2.createSecureServer(options, app).listen(3000)

--- a/examples/http2/package.json
+++ b/examples/http2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "http2",
+  "type": "module",
+  "dependencies": {
+    "@tinyhttp/app": "workspace:^0.2.13"
+  }
+}


### PR DESCRIPTION
I've added http/2 example. To get this up and running, you'll need to generate the certificate and key. Simply run

```
openssl req -x509 -newkey rsa:2048 -nodes -sha256 -subj '/CN=localhost' \
  -keyout localhost-privkey.pem -out localhost-cert.pem
```

then run it using `node index.js`.

Test this using `curl https://localhos:3000 -kiv`. You should see that the connection is using HTTP/2 instead of HTTP/1.1