### PR TITLE
refactor: update dev-server example

### DIFF
--- a/examples/dev-server/main.js
+++ b/examples/dev-server/main.js
@@ -1,12 +1,11 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
-const { hsr, clientPlugin } = require('sosse')
-const server = require('./server')
+const { hsr } = require('sosse')
 
 hsr({
   // Used as a prefix to resolve other configuration paths
   base: process.cwd(),
   // Will be called on file changes
-  main: () => server(),
-  plugins: [clientPlugin()],
+  main: () => require('./server')(),
+  plugins: [],
 })

--- a/examples/dev-server/package.json
+++ b/examples/dev-server/package.json
@@ -8,7 +8,7 @@
     "@tinyhttp/app": "workspace:*",
     "chokidar": "^3.4.1",
     "serve-handler": "^6.1.3",
-    "sosse": "^0.6.0"
+    "sosse": "^0.7.0"
   },
   "keywords": [],
   "author": "",

--- a/examples/dev-server/server.js
+++ b/examples/dev-server/server.js
@@ -2,21 +2,36 @@
 
 const { App } = require('@tinyhttp/app')
 const { createServer } = require('http')
-const { devSocket, useCtx } = require('sosse')
 const serve = require('serve-handler')
+const { devSocket, html, useCtx } = require('sosse')
 
 module.exports = async () => {
   const ctx = useCtx()
-
   const app = new App()
 
-  app.use((req, res) =>
-    serve(req, res, {
-      public: ctx.publicDir,
-    })
+  app.get('/', (req, res) => {
+    res.status(200).send(
+      html({
+        body: `
+        <h1>Some cool page</h1>
+        <h2>URL</h2>
+        ${req.url}
+        <h2>Params</h2>
+        ${JSON.stringify(req.params, null, 2)}`,
+        ctx,
+      })
+    )
+  })
+
+  app.use(
+    async (req, res) =>
+      await serve(req, res, {
+        directoryListing: false,
+        public: ctx.publicDir,
+      })
   )
 
-  const server = createServer(app.handler)
+  const server = createServer(app.handler.bind(app))
 
   const port = 3000
 
@@ -26,7 +41,6 @@ module.exports = async () => {
     server.listen(port)
 
     console.log(`Started http://localhost:${port}`)
-    return () =>
-      new Promise((res, rej) => server.close((e) => (e ? rej(e) : res())))
+    return () => new Promise((res, rej) => server.close((e) => (e ? rej(e) : res())))
   }
 }


### PR DESCRIPTION
Updating the dev-server example so that it:
- Reloads the server on changes
- Reloads the client
- Shows server errors on the client

P.S. i am not entirely sure whats the advertised use case with this example, but `serve-handler` seems to be a very "strict" static server middleware - it directly outputs a 404 if it fails to find a file for any request - instead of giving other middlewares the chance to do something better :D, so this makes it imho hard to use along with tinyhttp.