### PR TITLE
added https example

### DIFF
--- a/examples/https/README.md
+++ b/examples/https/README.md
@@ -1,0 +1,33 @@
+# HTTPS example
+
+Simple HTTPS server using `tinyhttp` and `https` module.
+
+## Setup
+Generate the certificate key.
+
+```sh
+openssl req -x509 -newkey rsa:2048 -nodes -sha256 -subj '/CN=localhost' \
+  -keyout localhost-privkey.pem -out localhost-cert.pem
+```
+
+Install all dependencies
+```sh
+pnpm install
+```
+
+## Run
+```sh
+node index.js
+```
+
+and in another terminal:
+
+```sh
+curl https://localhost:3000 -k
+```
+
+expected output:
+
+```sh
+Hello from https server!
+```

--- a/examples/https/index.js
+++ b/examples/https/index.js
@@ -1,0 +1,20 @@
+import { App } from '@tinyhttp/app'
+import fs from 'fs'
+import https from 'https'
+
+const app = new App({
+  settings: {
+    networkExtensions: true,
+  },
+})
+
+const options = {
+  key: fs.readFileSync('localhost-privkey.pem'),
+  cert: fs.readFileSync('localhost-cert.pem'),
+}
+
+app.get('/', (req, res) => res.send(`Hello from ${req.protocol} server!`))
+
+const server = https.createServer(options)
+
+server.on('request', async (req, res) => await app.handler(req, res)).listen(3000)

--- a/examples/https/package.json
+++ b/examples/https/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "https",
+  "type": "module",
+  "dependencies": {
+    "@tinyhttp/app": "^0.2.29"
+  }
+}


### PR DESCRIPTION
I've added the https example for tinyhttp ( see #21 for more examples ). To set this up, you'll need to generate the certificate and key for this example, run:

```sh
openssl req -x509 -newkey rsa:2048 -nodes -sha256 -subj '/CN=localhost' \
  -keyout localhost-privkey.pem -out localhost-cert.pem
```

Install the dependencies using `pnpm install`, then run the app using `node index.js`. Test it using `curl https://localhost:3000/ -k`. What you should get is `Hello from https server!`