### PR TITLE
:sparkles: implement req.ip and req.ips

### DIFF
--- a/__tests__/request.test.ts
+++ b/__tests__/request.test.ts
@@ -23,6 +23,34 @@ describe('Request properties', () => {
       done
     )
   })
+
+  it('req.ip & req.ips is being parsed properly', (done) => {
+    const { request } = InitAppAndTest(
+      (req, res) => {
+        res.json({
+          ip: req.ip,
+          ips: req.ips,
+        })
+      },
+      '/',
+      'GET',
+      {
+        settings: {
+          networkExtensions: true,
+        },
+      }
+    )
+
+    request.get('/').expect(
+      200,
+      {
+        ip: '127.0.0.1',
+        ips: ['::ffff:127.0.0.1'],
+      },
+      done
+    )
+  })
+
   it('req.params is being parsed properly', (done) => {
     const { request } = InitAppAndTest((req, res) => void res.send(req.params), '/:param1/:param2')
 

--- a/packages/app/src/extend.ts
+++ b/packages/app/src/extend.ts
@@ -5,6 +5,8 @@ import {
   getRangeFromHeader,
   checkIfXMLHttpRequest,
   getHostname,
+  getIP,
+  getIPs,
   getRequestHeader,
   setRequestHeader,
   getFreshOrStale,
@@ -38,6 +40,8 @@ export const extendMiddleware = (options: AppSettings) => (req: Request, res: Re
     })
 
     req.hostname = getHostname(req)
+    req.ip = getIP(req)
+    req.ips = getIPs(req)
   }
 
   req.query = getQueryParams(req.url)

--- a/packages/app/src/request.ts
+++ b/packages/app/src/request.ts
@@ -41,9 +41,7 @@ export const getProtocol = (req: Request): Protocol => {
   return index !== -1 ? header.substring(0, index).trim() : header.trim()
 }
 
-export const getRequestHeader = (req: Request) => (
-  header: string
-): string | string[] => {
+export const getRequestHeader = (req: Request) => (header: string): string | string[] => {
   const lc = header.toLowerCase()
 
   switch (lc) {
@@ -55,17 +53,11 @@ export const getRequestHeader = (req: Request) => (
   }
 }
 
-export const setRequestHeader = (req: Request) => (
-  field: string,
-  value: string
-) => {
+export const setRequestHeader = (req: Request) => (field: string, value: string) => {
   return (req.headers[field.toLowerCase()] = value)
 }
 
-export const getRangeFromHeader = (req: Request) => (
-  size: number,
-  options?: Options
-) => {
+export const getRangeFromHeader = (req: Request) => (size: number, options?: Options) => {
   const range = req.get('Range') as string
 
   if (!range) return
@@ -82,9 +74,7 @@ export const checkIfXMLHttpRequest = (req: Request): boolean => {
 }
 
 export const getHostname = (req: Request): string | undefined => {
-  let host: string | undefined = req.get('X-Forwarded-Host') as
-    | string
-    | undefined
+  let host: string | undefined = req.get('X-Forwarded-Host') as string | undefined
 
   if (!host || !compileTrust(req.connection.remoteAddress)) {
     host = req.get('Host') as string | undefined
@@ -99,8 +89,16 @@ export const getHostname = (req: Request): string | undefined => {
   return index !== -1 ? host.substring(0, index) : host
 }
 
-export const getIP = (req: Request) => {
-  return proxyAddr(req, compileTrust)
+export const getIP = (req: Request): string | undefined => {
+  const proxyFn = compileTrust(req.connection.remoteAddress)
+  const ip: string = proxyAddr(req, proxyFn).replace(/^.*:/, '') // striping the redundant prefix addeded by OS to IPv4 address
+  return ip
+}
+
+export const getIPs = (req: Request): string[] | undefined => {
+  const proxyFn = compileTrust(req.connection.remoteAddress)
+  const addrs: string[] = proxyAddr.all(req, proxyFn)
+  return addrs
 }
 
 // export const getRequestIs = (types: string | string[], ...args: string[]) => (req: Request) => {
@@ -134,9 +132,7 @@ export const getFreshOrStale = (req: Request, res: Response) => {
   return false
 }
 
-export const getAccepts = (req: Request) => (
-  ...types: string[]
-): string | false | string[] => {
+export const getAccepts = (req: Request) => (...types: string[]): string | false | string[] => {
   return new Accepts(req).types(types)
 }
 
@@ -158,6 +154,8 @@ export interface Request extends IncomingMessage {
 
   xhr: boolean
   hostname: string | undefined
+  ip?: string
+  ips?: string[]
 
   get: (header: string) => string | string[] | undefined
   set: (field: string, value: string) => string

--- a/packages/app/src/utils/request.ts
+++ b/packages/app/src/utils/request.ts
@@ -21,7 +21,8 @@ export const compileTrust = (val: any) => {
 
   if (typeof val === 'string') {
     // Support comma-separated values
-    val = val.split(/ *, */)
+    const vals = val.split(',').map((it) => it.trim())
+    return proxyAddr.compile(vals)
   }
 
   return proxyAddr.compile(val || [])


### PR DESCRIPTION
implement `req.ip` and `req.ips` . The implementation is a bit different from `express`.
- There was already an address `trust` function implemented in our codebase. and Both of these methods rely on that for making sure that the incoming address is trustworthy.
- `req.ips` returns all the `IP addresses` when the request is coming under a proxy. And when it there is no proxy it just returns the first [untrusted IP](https://www.npmjs.com/package/proxy-addr#proxyaddrallreq-trust) which is `127.0.0.1` in the local server
- `req.ip` method has a regex replacer in its return statement which removes the prefix added by the [OS to `IPv4` to convert it to `IPv6`](https://stackoverflow.com/a/35560645/9360234). Basically it just prefixes `:ffff:` in front of the IPv4. So that regex replacer removes this part from IP address

***test cases for both of these methods are added***