### PR TITLE
fix: changed the default binding address from localhost to 0.0.0.0

### DIFF
--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tinyhttp/app
 
+## 0.4.3
+
+### Patch Changes
+
+- Changed the default binding address from localhost to 0.0.0.0
+
 ## 0.4.2
 
 ### Patch Changes

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinyhttp/app",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "tinyhttp core with App, Request, Response and Router",
   "type": "module",
   "homepage": "https://github.com/talentlessguy/tinyhttp#readme",

--- a/packages/app/src/app.ts
+++ b/packages/app/src/app.ts
@@ -239,7 +239,7 @@ export class App<RenderOptions = any, Req extends Request = Request, Res extends
    * @param Server callback after server starts listening
    * @param host server listening host
    */
-  listen(port?: number, cb?: () => void, host = 'localhost') {
+  listen(port?: number, cb?: () => void, host = '0.0.0.0') {
     const server = createServer()
 
     server.on('request', (req, res) => this.handler(req, res))

--- a/packages/bot-detector/CHANGELOG.md
+++ b/packages/bot-detector/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @tinyhttp/bot-detector
 
+## 0.4.3
+
+### Patch Changes
+
+- Updated dependencies [undefined]
+  - @tinyhttp/app@0.4.3
+
 ## 0.4.2
 
 ### Patch Changes

--- a/packages/bot-detector/package.json
+++ b/packages/bot-detector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinyhttp/bot-detector",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "description": "Detect bots among users in your tinyhttp app.",
   "homepage": "https://github.com/talentlessguy/tinyhttp#readme",

--- a/packages/cookie-parser/CHANGELOG.md
+++ b/packages/cookie-parser/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @tinyhttp/cookie-parser
 
+## 0.4.3
+
+### Patch Changes
+
+- Updated dependencies [undefined]
+  - @tinyhttp/app@0.4.3
+
 ## 0.4.2
 
 ### Patch Changes

--- a/packages/cookie-parser/package.json
+++ b/packages/cookie-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinyhttp/cookie-parser",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "description": "tinyhttp cookie parsing middleware",
   "homepage": "https://github.com/talentlessguy/tinyhttp/tree/master/packages/cookie-parser#readme",

--- a/packages/ip-filter/CHANGELOG.md
+++ b/packages/ip-filter/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @tinyhttp/ip-filter
 
+## 0.4.3
+
+### Patch Changes
+
+- Updated dependencies [undefined]
+  - @tinyhttp/app@0.4.3
+
 ## 0.4.2
 
 ### Patch Changes

--- a/packages/ip-filter/package.json
+++ b/packages/ip-filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinyhttp/ip-filter",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "tinyhttp IP filtering middleware",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @tinyhttp/logger
 
+## 0.4.22
+
+### Patch Changes
+
+- Updated dependencies [undefined]
+  - @tinyhttp/app@0.4.3
+
 ## 0.4.21
 
 ### Patch Changes

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinyhttp/logger",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "type": "module",
   "description": "simple HTTP logger for tinyhttp",
   "homepage": "https://github.com/talentlessguy/tinyhttp#readme",

--- a/packages/markdown/CHANGELOG.md
+++ b/packages/markdown/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @tinyhttp/markdown
 
+## 0.4.3
+
+### Patch Changes
+
+- Updated dependencies [undefined]
+  - @tinyhttp/app@0.4.3
+
 ## 0.4.2
 
 ### Patch Changes

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinyhttp/markdown",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "tinyhttp static markdown middleware",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/pug/CHANGELOG.md
+++ b/packages/pug/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @tinyhttp/pug
 
+## 0.4.3
+
+### Patch Changes
+
+- Updated dependencies [undefined]
+  - @tinyhttp/app@0.4.3
+
 ## 0.4.2
 
 ### Patch Changes

--- a/packages/pug/package.json
+++ b/packages/pug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinyhttp/pug",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "description": "Pug wrapped in a helper function for tinyhttp.",
   "homepage": "https://github.com/talentlessguy/tinyhttp#readme",


### PR DESCRIPTION
Tinyhttp used to default to localhost when it came to bind an address, which is incompatible with 99% of serverless services (like Heroku), but now it defaults to 0.0.0.0

Fixes #85 