### PR TITLE
fix: added a check to see if types is undefined

### DIFF
--- a/packages/accepts/src/index.ts
+++ b/packages/accepts/src/index.ts
@@ -24,7 +24,7 @@ export class Accepts {
     // support flattened arguments
     if (types && !Array.isArray(types)) {
       mimeTypes = [types, ...args]
-    } else {
+    } else if (types) {
       mimeTypes = [...types, ...args]
     }
 


### PR DESCRIPTION
### FIX:
- if types was undefined it couldn't reach the step where it returned all the options, because it stopped with an error before that