### PR TITLE
#103: Add session example

### DIFF
--- a/examples/jwt/README.md
+++ b/examples/jwt/README.md
@@ -1,6 +1,6 @@
 # Auth example
 
-Simple authentification example using [JWT](https://jwt.io/) and tinyhttp.
+Simple authentication example using [JWT](https://jwt.io/) and tinyhttp.
 
 ## Setup
 

--- a/examples/session/README.md
+++ b/examples/session/README.md
@@ -1,0 +1,21 @@
+# Auth (Session) example
+
+Simple authentication example using tinyhttp/session.
+
+## Setup
+
+```sh
+pnpm install
+```
+
+## Run
+
+```sh
+node index.js
+```
+
+And in another terminal:
+
+```sh
+curl -X POST -F "user=admin" -F "pwd=admin" http://localhost:3000
+```

--- a/examples/session/README.md
+++ b/examples/session/README.md
@@ -24,8 +24,8 @@ curl -d "user=admin&pwd=admin" -v http://localhost:3000/login
 
 From the response of the above command, note the value of the `micro.sid` cookie value
 
-1. To verify session (replace the cookie value obtained from the above output)
+2. To verify session (replace the cookie value obtained from the above output)
 
 ```sh
-curl -H 'Cookie: micro.sid=COOKIE_VALUE_HERE http://localhost:3000/admin
+curl -H 'Cookie: micro.sid=COOKIE_VALUE_HERE' http://localhost:3000/admin
 ```

--- a/examples/session/README.md
+++ b/examples/session/README.md
@@ -1,6 +1,6 @@
 # Auth (Session) example
 
-Simple authentication example using tinyhttp/session.
+Simple authentication example with a session cookie using [@tinyhttp/session](https://tinyhttp.v1rtl.site/mw/session)
 
 ## Setup
 
@@ -16,6 +16,16 @@ node index.js
 
 And in another terminal:
 
+1. To login
+
 ```sh
-curl -X POST -F "user=admin" -F "pwd=admin" http://localhost:3000
+curl -d "user=admin&pwd=admin" -v http://localhost:3000/login
+```
+
+From the response of the above command, note the value of the `micro.sid` cookie value
+
+1. To verify session (replace the cookie value obtained from the above output)
+
+```sh
+curl -H 'Cookie: micro.sid=COOKIE_VALUE_HERE http://localhost:3000/admin
 ```

--- a/examples/session/index.js
+++ b/examples/session/index.js
@@ -1,0 +1,47 @@
+import { App } from '@tinyhttp/app'
+import { urlencoded } from 'body-parsec'
+import { SessionManager, MemoryStore } from '@tinyhttp/session'
+
+const app = new App()
+const store = new MemoryStore()
+
+app.use(urlencoded())
+
+const getSession = SessionManager({
+  store,
+  secret: 'super secret text',
+})
+
+app.get('/', (_req, res) => {
+  res.send('Go to "/login" page to login')
+})
+
+app.post('/login', async (req, res) => {
+  const { body } = req
+  const session = await getSession(req, res)
+
+  console.log(`Received body: ${JSON.stringify(req.body)}`)
+
+  if (body.user !== 'admin' || body.pwd !== 'admin') {
+    res.send('Incorrect login')
+    return
+  }
+
+  session.isLoggedIn = true
+  session.user = 'admin'
+
+  res.status(204).end()
+})
+
+app.get('/admin', async (req, res) => {
+  const session = await getSession(req, res)
+
+  if (!session.isLoggedIn) {
+    res.status(403).send('Authorized personnel only!')
+    return
+  }
+
+  return res.send(`Welcome ${session.user}`)
+})
+
+app.listen(3000)

--- a/examples/session/package.json
+++ b/examples/session/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "session",
+  "private": true,
+  "dependencies": {
+    "@tinyhttp/app": "workspace:*",
+    "@tinyhttp/session": "workspace:*",
+    "body-parsec": "^2.0.16"
+  },
+  "type": "module",
+  "module": "index.js"
+}


### PR DESCRIPTION
Implements #103 

Adding an example of an auth (session) using tinyhttp and [@tinyhttp/session](https://tinyhttp.v1rtl.site/mw/session)