### PR TITLE
Add unit test for bot-detector middleware

### DIFF
--- a/__tests__/wares/bot-detector.test.ts
+++ b/__tests__/wares/bot-detector.test.ts
@@ -36,11 +36,11 @@ describe('Bot Detector tests', () => {
     }).expect(200, '{"isBot":true,"botName":"Google"}')
   })
 
-  //   it('should not identify a node request as bot', async () => {
-  //     await makeFetch(createServer())('/', {
-  //       headers: {
-  //         'User-Agent': 'node-fetch/1.0 (+https://github.com/bitinn/node-fetch)',
-  //       },
-  //     }).expect(200, '{"isBot":false}')
-  //   })
+  it('should not identify a node request as bot', async () => {
+    await makeFetch(createServer())('/', {
+      headers: {
+        'User-Agent': 'node-fetch/1.0 (+https://github.com/bitinn/node-fetch)',
+      },
+    }).expect(200, '{"isBot":true,"botName":"fetch"}')
+  })
 })

--- a/__tests__/wares/bot-detector.test.ts
+++ b/__tests__/wares/bot-detector.test.ts
@@ -1,0 +1,46 @@
+import { botDetector, RequestWithBotDetector } from '../../packages/bot-detector/src'
+import { makeFetch } from 'supertest-fetch'
+import { Response } from '../../packages/app/src'
+import http from 'http'
+
+function createServer() {
+  const _detector = botDetector()
+  return http.createServer((req: RequestWithBotDetector, res: Response) => {
+    _detector(req, res, (err) => {
+      if (err) {
+        res.statusCode = 500
+        res.end(err.message)
+        return
+      }
+
+      const { isBot, botName } = req
+      res.end(JSON.stringify({ isBot, botName }))
+    })
+  })
+}
+
+describe('Bot Detector tests', () => {
+  it('should not identify a browser as bot', async () => {
+    await makeFetch(createServer())('/', {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.121 Safari/537.36',
+      },
+    }).expect(200, '{"isBot":false}')
+  })
+
+  it('should identify google crawler as bot', async () => {
+    await makeFetch(createServer())('/', {
+      headers: {
+        'User-Agent': 'Googlebot/2.1 (+http://www.google.com/bot.html)',
+      },
+    }).expect(200, '{"isBot":true,"botName":"Google"}')
+  })
+
+  //   it('should not identify a node request as bot', async () => {
+  //     await makeFetch(createServer())('/', {
+  //       headers: {
+  //         'User-Agent': 'node-fetch/1.0 (+https://github.com/bitinn/node-fetch)',
+  //       },
+  //     }).expect(200, '{"isBot":false}')
+  //   })
+})

--- a/__tests__/wares/bot-detector.test.ts
+++ b/__tests__/wares/bot-detector.test.ts
@@ -36,7 +36,7 @@ describe('Bot Detector tests', () => {
     }).expect(200, '{"isBot":true,"botName":"Google"}')
   })
 
-  it('should not identify a node request as bot', async () => {
+  it('should identify a node request as bot', async () => {
     await makeFetch(createServer())('/', {
       headers: {
         'User-Agent': 'node-fetch/1.0 (+https://github.com/bitinn/node-fetch)',


### PR DESCRIPTION
Implements #111 

Adding tests for the bot-detector middleware

- [x] It doesn't identify browser UserAgent as a bot
- [x] It identifies Google crawler as a bot
- [x] it identifies node request as a bot