### PR TITLE
reqIs does not correctly parse the Content-Type header #150

### DIFF
--- a/__tests__/modules/req.test.ts
+++ b/__tests__/modules/req.test.ts
@@ -1,5 +1,5 @@
 import { makeFetch } from 'supertest-fetch'
-import { checkIfXMLHttpRequest, getAccepts, getFreshOrStale, getRequestHeader } from '../../packages/req/src'
+import { checkIfXMLHttpRequest, getAccepts, getFreshOrStale, getRequestHeader, reqIs } from '../../packages/req/src'
 import { runServer } from '../../test_helpers/runServer'
 
 describe('Request extensions', () => {
@@ -85,5 +85,17 @@ describe('Request extensions', () => {
     })
 
     await makeFetch(app)('/').expect('rotten')
+  })
+  it('should ignore charset', async () => {
+    const app = runServer((req, res) => {
+      expect(reqIs(req)('text/html')).toBe('text/html')
+      res.end()
+    })
+    await makeFetch(app)('/', {
+      headers: {
+        'Content-Type': 'text/html; charset=UTF-8',
+      },
+    })
+    expect.assertions(1)
   })
 })

--- a/packages/type-is/package.json
+++ b/packages/type-is/package.json
@@ -41,9 +41,10 @@
   },
   "dependencies": {
     "es-mime-types": "^0.0.16",
-    "media-typer": "^1.1.0"
+    "content-type": "^1.0.4"
+
   },
   "devDependencies": {
-    "@types/media-typer": "^1.1.0"
+    "@types/content-type": "^1.1.0"
   }
 }

--- a/packages/type-is/package.json
+++ b/packages/type-is/package.json
@@ -40,11 +40,7 @@
     "build": "rollup -c"
   },
   "dependencies": {
-    "es-mime-types": "^0.0.16",
-    "content-type": "^1.0.4"
-
-  },
-  "devDependencies": {
-    "@types/content-type": "^1.1.0"
+    "es-content-type": "^0.0.10",
+    "es-mime-types": "^0.0.16"
   }
 }

--- a/packages/type-is/src/index.ts
+++ b/packages/type-is/src/index.ts
@@ -1,12 +1,12 @@
 import * as mime from 'es-mime-types'
-import typer from 'media-typer'
+import contentType from 'content-type'
 
 function normalizeType(value: string) {
   // parse the type
-  const type = typer.parse(value)
-
+  const type = contentType.parse(value)
+  type.parameters = {}
   // reformat it
-  return typer.format(type)
+  return contentType.format(type)
 }
 
 function tryNormalizeType(value: string) {

--- a/packages/type-is/src/index.ts
+++ b/packages/type-is/src/index.ts
@@ -1,12 +1,12 @@
 import * as mime from 'es-mime-types'
-import contentType from 'content-type'
+import typer from 'es-content-type'
 
 function normalizeType(value: string) {
   // parse the type
-  const type = contentType.parse(value)
+  const type = typer.parse(value)
   type.parameters = {}
   // reformat it
-  return contentType.format(type)
+  return typer.format(type)
 }
 
 function tryNormalizeType(value: string) {


### PR DESCRIPTION
To fix #150 I've replaced media-typer with another module from the same library (jshttp) that is more appropriate to parse a content type header (as stated in media-typer readme https://github.com/jshttp/media-typer#media-typer)