### PR TITLE
Tests for session.save, session.touch, session.destroy

### DIFF
--- a/__tests__/wares/session.test.ts
+++ b/__tests__/wares/session.test.ts
@@ -187,4 +187,26 @@ describe('getSession(req, res)', () => {
       expect(postTouchExpires.getTime() > preTouchExpires.getTime())
     })
   })
+
+  describe('session.destroy(cb)', () => {
+    it('should destroy the previous session', async () => {
+      const getSession = SessionManager({
+        secret: 'test',
+      })
+
+      const { fetch } = InitAppAndTest(async (req, res) => {
+        const session = await getSession(req, res)
+
+        session.destroy((err) => {
+          if (err) {
+            res.statusCode = 500
+          }
+
+          res.end(String(session))
+        })
+      })
+
+      await fetch('/').expectStatus(200).expectHeader('Set-Cookie', null)
+    })
+  })
 })

--- a/__tests__/wares/session.test.ts
+++ b/__tests__/wares/session.test.ts
@@ -38,4 +38,107 @@ describe('getSession(req, res)', () => {
 
     await fetch('/').expect({ t: 1 })
   })
+
+  describe('session.save(cb)', () => {
+    it('should save session to store', async () => {
+      const store = new MemoryStore()
+
+      const getSession = SessionManager({
+        store,
+        secret: 'test',
+      })
+
+      const { fetch } = InitAppAndTest(async (req, res) => {
+        const session = await getSession(req, res)
+
+        session.save((err) => {
+          if (err) {
+            return res.end(err.message)
+          }
+
+          store.get(session.id, (err, sess) => {
+            if (err) {
+              return res.end(err.message)
+            }
+
+            res.end(sess ? 'stored' : 'empty')
+          })
+        })
+      })
+
+      await fetch('/').expectStatus(200).expectBody('stored')
+    })
+
+    it('should prevent end-of-request save', async () => {
+      const store = new MemoryStore()
+
+      const _set = store.set
+
+      let setCount = 0
+
+      store.set = function set(...args) {
+        setCount++
+
+        return _set.apply(this, args)
+      }
+
+      const getSession = SessionManager({
+        store,
+        secret: 'test',
+      })
+
+      const { fetch } = InitAppAndTest(async (req, res) => {
+        const session = await getSession(req, res)
+
+        session.save((err) => {
+          if (err) {
+            return res.end(err.message)
+          }
+
+          res.end('saved')
+        })
+      })
+
+      await fetch('/').expectStatus(200).expectBody('saved')
+
+      expect(setCount).toBe(1)
+    })
+
+    it('should prevent end-of-request save on reloaded session', async () => {
+      const store = new MemoryStore()
+
+      const _set = store.set
+
+      let setCount = 0
+
+      store.set = function set(...args) {
+        setCount++
+
+        return _set.apply(this, args)
+      }
+
+      const getSession = SessionManager({
+        store,
+        secret: 'test',
+      })
+
+      const { fetch } = InitAppAndTest(async (req, res) => {
+        const session = await getSession(req, res)
+
+        session.reload(() => {
+          session.save((err) => {
+            if (err) {
+              return res.end(err.message)
+            }
+
+            res.end('saved')
+          })
+        })
+      })
+
+      await fetch('/').expectStatus(200).expectBody('saved')
+
+      expect(setCount).toBe(1)
+    })
+  })
 })

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -43,8 +43,8 @@ class Cookie implements Express.SessionCookie {
   domain?: string
   sameSite: boolean | 'lax' | 'strict' | 'none' | undefined
 
-  constructor(options?: Express.SessionCookieData) {
-    const opts: Partial<Express.SessionCookieData> = options || {}
+  constructor(options?: Partial<Express.SessionCookieData>) {
+    const opts = options || {}
 
     this.expires = opts.expires || false
     this.path = opts.path || '/'

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -262,7 +262,7 @@ export type SessionOptions = Partial<{
   /**
    * Settings object for the session ID cookie.
    */
-  cookie: Express.SessionCookieData
+  cookie: Partial<Express.SessionCookieData>
 }> & {
   secret: string | string[]
 }


### PR DESCRIPTION
- [ ] `SessionManager(opts)`
  - [ ] more coming soon....
- [ ] `getSession(req, res)`
  - [x] `session.save(cb)`
    - [x] Should save session to store ([src](https://github.com/expressjs/session/blob/master/test/session.js#L1762))
    - [x] Should prevent end-of-request save ([src](https://github.com/expressjs/session/blob/master/test/session.js#L1780))
    - [x] Should prevent end-of-request save on reloaded session
  - [x] `session.touch(cb)` ([src](https://github.com/expressjs/session/blob/master/test/session.js#L1829))
  - [x] `session.destroy(cb)`
  - [ ] `session.cookie` ([src](https://github.com/expressjs/session/blob/master/test/session.js#L1864))
  - [ ] `session.originalMaxAge` ([src](https://github.com/expressjs/session/blob/master/test/session.js#L1948))
  - and the rest of `session` properties :D
- [ ] `Cookie`
    - [ ] `new Cookie(opts)`
      - [ ] `expires` is falsy be default
      - [ ] `httpOnly` is true by default