### PR TITLE
test: add tests for type-is module

### DIFF
--- a/__tests__/modules/type-is.test.ts
+++ b/__tests__/modules/type-is.test.ts
@@ -1,0 +1,51 @@
+import { typeIs } from '../../packages/type-is/src'
+
+describe('typeIs', () => {
+  it('should return false when value is falsy', () => {
+    expect(typeIs('')).toBe(false)
+    expect(typeIs(null)).toBe(false)
+    expect(typeIs(undefined)).toBe(false)
+  })
+
+  it('should return value if types are empty', () => {
+    expect(typeIs('application/json')).toBe('application/json')
+  })
+
+  it("shouldn't depends on case", () => {
+    expect(typeIs('Application/Json')).toBe('application/json')
+  })
+
+  it('should return value if types are empty', () => {
+    expect(typeIs('application/json', ...['application/json'])).toBe('application/json')
+  })
+
+  it('should return value if matched type starts with plus', () => {
+    expect(typeIs('application/ld+json', '+json')).toBe('application/ld+json')
+  })
+
+  it('should return false if there is no match', () => {
+    expect(typeIs('application/ld+json', 'application/javascript')).toBe(false)
+  })
+
+  it('should return false if there is no match', () => {
+    expect(typeIs('text/html', 'application/javascript')).toBe(false)
+  })
+
+  it('should return matched value for urlencoded shorthand', () => {
+    expect(typeIs('application/x-www-form-urlencoded', 'urlencoded')).toBe('urlencoded')
+  })
+
+  it('should return matched value for urlencoded shorthand', () => {
+    expect(typeIs('multipart/form-data', 'multipart')).toBe('multipart')
+  })
+
+  it('should return false if types are not strings', () => {
+    expect(typeIs('multipart/form-data', false as any)).toBe(false)
+    expect(typeIs('multipart/form-data', null as any)).toBe(false)
+    expect(typeIs('multipart/form-data', undefined as any)).toBe(false)
+  })
+
+  it('should return false if expected type has wrong format', () => {
+    expect(typeIs('multipart/form-data', 'application/javascript/wrong')).toBe(false)
+  })
+})

--- a/__tests__/modules/type-is.test.ts
+++ b/__tests__/modules/type-is.test.ts
@@ -11,7 +11,7 @@ describe('typeIs', () => {
     expect(typeIs('application/json')).toBe('application/json')
   })
 
-  it("shouldn't depends on case", () => {
+  it("shouldn't depend on case", () => {
     expect(typeIs('Application/Json')).toBe('application/json')
   })
 


### PR DESCRIPTION
Now almost all lines in `type-is` module are covered by tests