### PR TITLE
Remove undefined from NextFunction

### DIFF
--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -2,7 +2,7 @@ import { METHODS, IncomingMessage as I, ServerResponse as R } from 'http'
 
 /* HELPER TYPES */
 
-export type NextFunction = (err?: any) => void | undefined
+export type NextFunction = (err?: any) => void
 
 export type SyncHandler<Request extends any = I, Response extends any = R> = (
   req: Request,


### PR DESCRIPTION
It seems like tinyhttp is incompatible with Express' NextFunction, making types for middleware that was originally designed for Express invalid. If this is intentional or if I'm wrong, feel free to just close this PR 😸 