### PR TITLE
Ability to send null .json responses

### DIFF
--- a/packages/send/src/json.ts
+++ b/packages/send/src/json.ts
@@ -10,6 +10,6 @@ export const json = <Response extends Res = Res>(res: Response) => (body: any, .
   res.setHeader('Content-Type', 'application/json')
   if (typeof body === 'object' && body != null) res.end(JSON.stringify(body, null, 2), ...args)
   else if (typeof body === 'string') res.end(body, ...args)
-  else if (typeof body === null) res.end(body, ...args);
+  else if (typeof body === 'null') res.end(body, ...args);
   return res
 }

--- a/packages/send/src/json.ts
+++ b/packages/send/src/json.ts
@@ -10,6 +10,6 @@ export const json = <Response extends Res = Res>(res: Response) => (body: any, .
   res.setHeader('Content-Type', 'application/json')
   if (typeof body === 'object' && body != null) res.end(JSON.stringify(body, null, 2), ...args)
   else if (typeof body === 'string') res.end(body, ...args)
-  else if (typeof body === 'null') res.end(body, ...args);
+  else if(body == null) res.end(null, ...args);
   return res
 }

--- a/packages/send/src/json.ts
+++ b/packages/send/src/json.ts
@@ -10,6 +10,6 @@ export const json = <Response extends Res = Res>(res: Response) => (body: any, .
   res.setHeader('Content-Type', 'application/json')
   if (typeof body === 'object' && body != null) res.end(JSON.stringify(body, null, 2), ...args)
   else if (typeof body === 'string') res.end(body, ...args)
-  else if(body == null) res.end(null, ...args);
+  else if(body == null) res.end(null, ...args)
   return res
 }

--- a/packages/send/src/json.ts
+++ b/packages/send/src/json.ts
@@ -10,6 +10,6 @@ export const json = <Response extends Res = Res>(res: Response) => (body: any, .
   res.setHeader('Content-Type', 'application/json')
   if (typeof body === 'object' && body != null) res.end(JSON.stringify(body, null, 2), ...args)
   else if (typeof body === 'string') res.end(body, ...args)
-  else if(body == null) res.end(null, ...args)
+  else if (body == null) res.end(null, ...args)
   return res
 }

--- a/packages/send/src/json.ts
+++ b/packages/send/src/json.ts
@@ -10,6 +10,6 @@ export const json = <Response extends Res = Res>(res: Response) => (body: any, .
   res.setHeader('Content-Type', 'application/json')
   if (typeof body === 'object' && body != null) res.end(JSON.stringify(body, null, 2), ...args)
   else if (typeof body === 'string') res.end(body, ...args)
-
+  else if (typeof body === null) res.end(body, ...args);
   return res
 }


### PR DESCRIPTION
this should fix the issue https://github.com/talentlessguy/tinyhttp/issues/223 where res.json() cant send null responses.