### PR TITLE
fix: #229 - CORS response on preflight

### DIFF
--- a/__tests__/wares/cors.test.ts
+++ b/__tests__/wares/cors.test.ts
@@ -48,7 +48,22 @@ describe('CORS headers tests', () => {
 
     await fetch('/').expect('Access-Control-Allow-Methods', 'GET')
   })
-  it('should send 204 and finish the request', async () => {
+  it('should set custom max-age', async () => {
+    const { fetch } = InitAppAndTest(cors({ maxAge: 86400 }))
+
+    await fetch('/').expect('Access-Control-Max-Age', '86400')
+  })
+  it('should set custom credentials', async () => {
+    const { fetch } = InitAppAndTest(cors({ credentials: true }))
+
+    await fetch('/').expect('Access-Control-Allow-Credentials', 'true')
+  })
+  it('should set custom exposed headers', async () => {
+    const { fetch } = InitAppAndTest(cors({ exposedHeaders: ['Content-Range', 'X-Content-Range'] }))
+
+    await fetch('/').expect('Access-Control-Expose-Headers', 'Content-Range, X-Content-Range')
+  })
+  it('should send 204 and continue the request', async () => {
     const app = createServer((req, res) => {
       cors({
         preflightContinue: false
@@ -57,9 +72,9 @@ describe('CORS headers tests', () => {
 
     const fetch = makeFetch(app)
 
-    await fetch('/').expect(204)
+    await fetch('/', { method: 'OPTIONS' }).expectStatus(204)
   })
-  it('should send 204 and continue the request', async () => {
+  it('should send 200 and continue the request', async () => {
     const app = createServer((req, res) => {
       cors({
         preflightContinue: true
@@ -72,7 +87,7 @@ describe('CORS headers tests', () => {
 
     await fetch('/').expect(200, 'something else?')
   })
-  it('should send 204 and continue the request', async () => {
+  it('should send 200 and continue the request', async () => {
     const app = createServer((req, res) => {
       cors()(req, res)
 

--- a/__tests__/wares/cors.test.ts
+++ b/__tests__/wares/cors.test.ts
@@ -63,6 +63,11 @@ describe('CORS headers tests', () => {
 
     await fetch('/').expect('Access-Control-Expose-Headers', 'Content-Range, X-Content-Range')
   })
+  it('should set custom allowed headers', async () => {
+    const { fetch } = InitAppAndTest(cors({ allowedHeaders: ['Content-Range', 'X-Content-Range'] }))
+
+    await fetch('/').expect('Access-Control-Allow-Headers', 'Content-Range, X-Content-Range')
+  })
   it('should send 204 and continue the request', async () => {
     const app = createServer((req, res) => {
       cors({
@@ -73,6 +78,18 @@ describe('CORS headers tests', () => {
     const fetch = makeFetch(app)
 
     await fetch('/', { method: 'OPTIONS' }).expectStatus(204)
+  })
+  it('should send 200 and continue the request', async () => {
+    const app = createServer((req, res) => {
+      cors({
+        preflightContinue: true
+      })(req, res)
+      res.end('something more')
+    })
+
+    const fetch = makeFetch(app)
+
+    await fetch('/', { method: 'OPTIONS' }).expect(200, 'something more')
   })
   it('should send 200 and continue the request', async () => {
     const app = createServer((req, res) => {

--- a/packages/cors/README.md
+++ b/packages/cors/README.md
@@ -40,7 +40,7 @@ The default configuration is:
   "origin": "*",
   "methods": ["GET", "HEAD", "PUT", "PATCH", "POST", "DELETE"],
   "optionsSuccessStatus": 204,
-  "preflightContinue": true
+  "preflightContinue": false
 }
 ```
 

--- a/packages/cors/package.json
+++ b/packages/cors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinyhttp/cors",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "tinyhttp CORS module",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/cors/src/index.ts
+++ b/packages/cors/src/index.ts
@@ -60,8 +60,7 @@ export const cors = (opts: AccessControlOptions = {}) => {
     // Setting the Access-Control-Max-Age header
     if (maxAge) res.setHeader('Access-Control-Max-Age', maxAge)
 
-    const method = req.method && req.method.toUpperCase && req.method.toUpperCase()
-    if (method === 'OPTIONS') {
+    if (req.method?.toUpperCase?.() === 'OPTIONS') {
       if (preflightContinue) {
         next?.()
       } else {

--- a/packages/cors/src/index.ts
+++ b/packages/cors/src/index.ts
@@ -24,7 +24,7 @@ export const cors = (opts: AccessControlOptions = {}) => {
     credentials,
     maxAge,
     optionsSuccessStatus = 204,
-    preflightContinue = true
+    preflightContinue = false
   } = opts
   return (req: Request, res: Response, next?: () => void) => {
     // Checking the type of the origin property
@@ -60,11 +60,17 @@ export const cors = (opts: AccessControlOptions = {}) => {
     // Setting the Access-Control-Max-Age header
     if (maxAge) res.setHeader('Access-Control-Max-Age', maxAge)
 
-    if (preflightContinue) {
-      next?.()
+    const method = req.method && req.method.toUpperCase && req.method.toUpperCase()
+    if (method === 'OPTIONS') {
+      if (preflightContinue) {
+        next?.()
+      } else {
+        res.statusCode = optionsSuccessStatus
+        res.setHeader('Content-Length', '0')
+        res.end()
+      }
     } else {
-      res.statusCode = optionsSuccessStatus
-      res.end()
+      next?.()
     }
   }
 }


### PR DESCRIPTION
fix!: preflightContinue defaults to false again now
fix: added preflight just for options method (as per express' cors)
chore: bump version

I've put a sample repo with this version on https://github.com/aldy505/tinyhttp-cors-test