### PR TITLE
feat(cors): set default allowed headers to content-type

### DIFF
--- a/packages/cors/src/index.ts
+++ b/packages/cors/src/index.ts
@@ -19,7 +19,7 @@ export const cors = (opts: AccessControlOptions = {}) => {
   const {
     origin = '*',
     methods = ['GET', 'HEAD', 'PUT', 'PATCH', 'POST', 'DELETE'],
-    allowedHeaders,
+    allowedHeaders = ['content-type'],
     exposedHeaders,
     credentials,
     maxAge,


### PR DESCRIPTION
closes https://github.com/talentlessguy/tinyhttp/issues/256