### PR TITLE
TypeError: Cannot convert undefined or null to object for projects without dev dependencies in CLI

### DIFF
--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -73,7 +73,7 @@ export const installPackages = async (pkg: string) => {
     .save()
 
   const depCount =
-    (Object.keys(file.get('dependencies')) || []).length + (Object.keys(file.get('devDependencies')) || []).length
+    (Object.keys(file.get('dependencies')) || []).length + (Object.keys(file.get('devDependencies') || {}) || []).length
 
   const spinner = ora()
 


### PR DESCRIPTION
Fixes #259
Hi @talentlessguy, how does this look?
Let me know if this needs any changes.
Thanks