### PR TITLE
docs(cookie): add JSDoc for `serialize` function and `SerializeOptions`

### DIFF
--- a/packages/cookie/src/index.ts
+++ b/packages/cookie/src/index.ts
@@ -56,17 +56,103 @@ export function parse(
   return obj
 }
 
+/**
+ * Options for the {@link serialize} function.
+ */
 export type SerializeOptions = Partial<{
+  /**
+   * A function to encode the cookie value.
+   * Defaults to `encodeURIComponent`.
+   */
   encode: (str: string) => string
+
+  /**
+   * Specifies the `Max-Age` attribute in seconds.
+   * A zero or negative number will expire the cookie immediately.
+   * If both `expires` and `maxAge` are set, `maxAge` takes precedence.
+   *
+   * @see https://tools.ietf.org/html/rfc6265#section-5.2.2
+   */
   maxAge: number
+
+  /**
+   * Specifies the `Domain` attribute.
+   * By default, no domain is set, and most clients will consider
+   * the cookie to apply to only the current domain.
+   *
+   * @see https://tools.ietf.org/html/rfc6265#section-5.2.3
+   */
   domain: string
+
+  /**
+   * Specifies the `Path` attribute.
+   * By default, the path is considered the "default path".
+   *
+   * @see https://tools.ietf.org/html/rfc6265#section-5.2.4
+   */
   path: string
+
+  /**
+   * Specifies the `HttpOnly` attribute.
+   * When truthy, the `HttpOnly` attribute is set; otherwise it is not.
+   * Mitigates the risk of client-side script accessing the protected cookie.
+   *
+   * @see https://tools.ietf.org/html/rfc6265#section-5.2.6
+   */
   httpOnly: boolean
+
+  /**
+   * Specifies the `Secure` attribute.
+   * When truthy, the `Secure` attribute is set; otherwise it is not.
+   * The cookie will only be sent over HTTPS.
+   *
+   * @see https://tools.ietf.org/html/rfc6265#section-5.2.5
+   */
   secure: boolean
+
+  /**
+   * Specifies the `SameSite` attribute.
+   * - `true` or `'Strict'`: strictly same site
+   * - `'Lax'`: lax same site (sent with top-level navigations)
+   * - `'None'`: no same-site restriction (requires `Secure`)
+   *
+   * @see https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.2.7
+   */
   sameSite: boolean | 'Strict' | 'strict' | 'Lax' | 'lax' | 'None' | 'none' | string
+
+  /**
+   * Specifies the `Expires` attribute as a `Date` object.
+   * If not set, the cookie will be treated as a session cookie and
+   * removed when the browser is closed.
+   *
+   * @see https://tools.ietf.org/html/rfc6265#section-5.2.1
+   */
   expires: Date
 }>
 
+/**
+ * Serialize a cookie name-value pair into a `Set-Cookie` header string.
+ *
+ * @param name - The name of the cookie. Must only contain valid US-ASCII characters.
+ * @param val - The value of the cookie.
+ * @param opt - Optional serialization options (encoding, flags, expiry, etc.).
+ * @returns A string suitable for use as the value of a `Set-Cookie` HTTP header.
+ * @throws {TypeError} If the cookie name or value contains invalid characters,
+ *   or if any of the provided options are invalid.
+ *
+ * @example
+ * ```ts
+ * import { serialize } from '@tinyhttp/cookie'
+ *
+ * const header = serialize('session', 'abc123', {
+ *   httpOnly: true,
+ *   secure: true,
+ *   sameSite: 'Lax',
+ *   maxAge: 3600
+ * })
+ * // => 'session=abc123; Max-Age=3600; HttpOnly; Secure; SameSite=Lax'
+ * ```
+ */
 export function serialize(name: string, val: string, opt: SerializeOptions = {}): string {
   if (!opt.encode) opt.encode = encodeURIComponent
 


### PR DESCRIPTION
## Summary

Fixes #492

The `serialize` function and `SerializeOptions` type are part of the public API but lacked JSDoc comments. This PR adds comprehensive inline documentation to improve the IDE developer experience.

## Changes

- Added JSDoc to the `SerializeOptions` type with individual field descriptions (including RFC links for `maxAge`, `domain`, `path`, `httpOnly`, `secure`, `sameSite`, `expires`)
- Added full JSDoc to the `serialize()` function including:
  - `@param` for all parameters
  - `@returns` description
  - `@throws` for `TypeError` cases
  - `@example` block showing real-world usage

## Before vs After

**Before:** `SerializeOptions` fields showed no hover info in IDE. `serialize()` had no documentation.

**After:** All fields are documented with descriptions and RFC links. Users get inline help for every option.

## Testing

No logic changes — this is documentation-only. Existing tests pass without modification.