### PR TITLE
fix: prevent sendFile root path traversal

### DIFF
--- a/.changeset/wicked-pans-jam.md
+++ b/.changeset/wicked-pans-jam.md
@@ -1,0 +1,5 @@
+---
+"@tinyhttp/send": patch
+---
+
+Fix root traversal in sendFile

--- a/packages/send/src/sendFile.ts
+++ b/packages/send/src/sendFile.ts
@@ -1,8 +1,10 @@
 import { createReadStream, statSync } from 'node:fs'
 import type { IncomingMessage as I, IncomingHttpHeaders, ServerResponse as S } from 'node:http'
-import { extname, isAbsolute, join } from 'node:path'
+import { extname, isAbsolute, join, normalize, sep } from 'node:path'
 import mime from 'mime'
 import { createETag } from './utils.js'
+
+const UP_PATH_REGEXP = /(?:^|[\\/])\.\.(?:[\\/]|$)/
 
 export type ReadStreamOptions = Partial<{
   flags: string
@@ -61,7 +63,15 @@ export const sendFile =
 
     if (caching) enableCaching(res, caching)
 
-    const filePath = root ? join(root, path) : path
+    const filePath = root
+      ? (() => {
+          const normalizedPath = normalize(`.${sep}${path}`)
+
+          if (UP_PATH_REGEXP.test(normalizedPath)) throw new TypeError('path must not contain ".."')
+
+          return join(root, normalizedPath)
+        })()
+      : path
 
     const stats = statSync(filePath)
 

--- a/tests/modules/send.test.ts
+++ b/tests/modules/send.test.ts
@@ -218,6 +218,55 @@ describe('sendFile(path)', () => {
 
     await makeFetch(app)('/').expectHeader('Content-Type', 'text/plain; charset=utf-8')
   })
+  it('should send a relative path inside root', async () => {
+    const app = runServer((req, res) => sendFile(req, res)('test.txt', { root: __dirname }))
+
+    await makeFetch(app)('/').expect('Hello World')
+  })
+  it('should send a normalized path inside root', async () => {
+    const app = runServer((req, res) => sendFile(req, res)('foo/../test.txt', { root: __dirname }))
+
+    await makeFetch(app)('/').expect('Hello World')
+  })
+  it('should keep an absolute-looking path inside root', async () => {
+    const app = runServer((req, res) => sendFile(req, res)('/test.txt', { root: __dirname }))
+
+    await makeFetch(app)('/').expect('Hello World')
+  })
+  it('should throw if path traverses outside root', async () => {
+    const app = runServer((req, res) => {
+      try {
+        sendFile(req, res)('../relative/path', { root: __dirname })
+      } catch (err) {
+        expect(err.message).toMatch(/must not contain/)
+
+        res.end()
+
+        return
+      }
+
+      throw new Error('Did not throw an error')
+    })
+
+    await makeFetch(app)('/')
+  })
+  it('should throw if normalized path traverses outside root', async () => {
+    const app = runServer((req, res) => {
+      try {
+        sendFile(req, res)('foo/../../test.txt', { root: __dirname })
+      } catch (err) {
+        expect(err.message).toMatch(/must not contain/)
+
+        res.end()
+
+        return
+      }
+
+      throw new Error('Did not throw an error')
+    })
+
+    await makeFetch(app)('/')
+  })
   it('should inherit the previously set Content-Type header', async () => {
     const app = runServer((req, res) => {
       res.setHeader('Content-Type', 'text/markdown')


### PR DESCRIPTION
## Summary
- reject `..` path traversal attempts before joining relative `sendFile` paths with `root`
- normalize relative and absolute-looking rooted paths so safe in-root paths still resolve correctly
- add regression tests for blocked traversal and allowed rooted paths

## Testing
- `pnpm exec biome check packages/send/src/sendFile.ts tests/modules/send.test.ts`
- `pnpm exec vitest tests/modules/send.test.ts`
- `pnpm test`