### PR TITLE
refactor(dotenv): mirror motdotla/dotenv parser rewrite

### DIFF
--- a/.changeset/clever-moons-deny.md
+++ b/.changeset/clever-moons-deny.md
@@ -1,0 +1,5 @@
+---
+"@tinyhttp/dotenv": major
+---
+
+Rewrite @tinyhttp/dotenv to mirror latest dotenv's changes

--- a/packages/dotenv/src/index.ts
+++ b/packages/dotenv/src/index.ts
@@ -4,56 +4,39 @@ import type { DotenvConfigOptions, DotenvConfigOutput, DotenvParseOptions, Doten
 
 const log = (message: string) => console.log(`[dotenv][DEBUG] ${message}`)
 
-const NEWLINE = '\n'
-const RE_INI_KEY_VAL = /^\s*([\w.-]+)\s*=\s*(.*)?\s*$/
-const RE_NEWLINES = /\\n/g
-const NEWLINES_MATCH = /\n|\r|\r\n/
+// Mirrors motdotla/dotenv parser: one multiline regex, no polynomial backtracking.
+// Matches: optional `export`, KEY, `=` or `:`, then a quoted ('/"/`) or unquoted value, optional trailing comment.
+const LINE =
+  /(?:^|^)\s*(?:export\s+)?([\w.-]+)(?:\s*=\s*?|:\s+?)(\s*'(?:\\'|[^'])*'|\s*"(?:\\"|[^"])*"|\s*`(?:\\`|[^`])*`|[^#\r\n]+)?\s*(?:#.*)?(?:$|$)/gm
 
 /**
  * Parses a string or buffer in the .env file format into an object.
  *
  * @param src - contents to be parsed
- * @param options - additional options
  * @returns an object with keys and values based on `src`
  */
-export function parse(src: string | Buffer, options?: DotenvParseOptions): DotenvParseOutput {
-  const debug = Boolean(options?.debug)
-  const obj = {}
+export function parse(src: string | Buffer, _options?: DotenvParseOptions): DotenvParseOutput {
+  const obj: DotenvParseOutput = {}
+  // normalize line endings so the `m` flag anchors work consistently
+  const lines = src.toString().replace(/\r\n?/gm, '\n')
 
-  // convert Buffers before splitting into lines and processing
-  src
-    .toString()
-    .split(NEWLINES_MATCH)
-    .forEach((line: string, idx: number) => {
-      // matching "KEY' and 'VAL' in 'KEY=VAL'
-      const keyValueArr = line.match(RE_INI_KEY_VAL)
-      // matched?
-      if (keyValueArr != null) {
-        const key = keyValueArr[1]
-        // default undefined or missing values to empty string
-        let val = keyValueArr[2] || ''
-        const end = val.length - 1
-        const isDoubleQuoted = val[0] === '"' && val[end] === '"'
-        const isSingleQuoted = val[0] === "'" && val[end] === "'"
+  let match: RegExpExecArray | null
+  // biome-ignore lint/suspicious/noAssignInExpressions: idiomatic regex loop
+  while ((match = LINE.exec(lines)) != null) {
+    const key = match[1]
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue
 
-        // if single or double quoted, remove quotes
-        if (isSingleQuoted || isDoubleQuoted) {
-          val = val.substring(1, end)
+    let value = (match[2] || '').trim()
+    const quote = value[0]
 
-          // if double quoted, expand newlines
-          if (isDoubleQuoted) {
-            val = val.replace(RE_NEWLINES, NEWLINE)
-          }
-        } else {
-          // remove surrounding whitespace
-          val = val.trim()
-        }
+    // strip surrounding matching quotes (`, ', ")
+    value = value.replace(/^(['"`])([\s\S]*)\1$/gm, '$2')
 
-        obj[key] = val
-      } else if (debug) {
-        log(`did not match key and value when parsing line ${idx + 1}: ${line}`)
-      }
-    })
+    // expand escapes only inside double quotes
+    if (quote === '"') value = value.replace(/\\n/g, '\n').replace(/\\r/g, '\r')
+
+    obj[key] = value
+  }
 
   return obj
 }
@@ -64,27 +47,29 @@ export function parse(src: string | Buffer, options?: DotenvParseOptions): Doten
  *
  * @param options - controls behavior
  * @returns an object with a `parsed` key if successful or `error` key if an error occurred
- *
  */
 export function config(options?: Partial<DotenvConfigOptions>): DotenvConfigOutput {
   const dotenvPath = options?.path || path.resolve(process.cwd(), '.env')
   const encoding = options?.encoding || 'utf8'
   const debug = options?.debug || false
+  const override = options?.override || false
+  const processEnv = options?.processEnv || process.env
 
   try {
-    // specifying an encoding returns a string instead of a buffer
-    const parsed = parse(readFileSync(dotenvPath, { encoding }), { debug })
+    const parsed = parse(readFileSync(dotenvPath, { encoding }))
 
     for (const key of Object.keys(parsed)) {
-      if (!Object.hasOwn(process.env, key)) {
-        process.env[key] = parsed[key]
-      } else if (debug) {
-        log(`"${key}" is already defined in \`process.env\` and will not be overwritten`)
+      if (Object.hasOwn(processEnv, key)) {
+        if (override) processEnv[key] = parsed[key]
+        if (debug) log(`"${key}" is already defined in \`process.env\` and ${override ? 'WAS' : 'was NOT'} overwritten`)
+      } else {
+        processEnv[key] = parsed[key]
       }
     }
 
     return { parsed }
   } catch (error) {
+    if (debug) log(`failed to load ${dotenvPath}: ${(error as Error).message}`)
     return { error: error as Error }
   }
 }

--- a/packages/dotenv/src/types.ts
+++ b/packages/dotenv/src/types.ts
@@ -1,7 +1,7 @@
 /* c8 ignore start */
 export interface DotenvParseOptions {
   /**
-   * You may turn on logging to help debug why certain keys or values are not being set as you expect.
+   * @deprecated Kept for backwards-compatibility. The new parser does not log per-line warnings.
    */
   debug?: boolean
 }
@@ -25,6 +25,18 @@ export type DotenvConfigOptions = {
    * You may turn on logging to help debug why certain keys or values are not being set as you expect.
    */
   debug: boolean
+
+  /**
+   * Override any environment variables that have already been set.
+   * @default false
+   */
+  override: boolean
+
+  /**
+   * Specify an object to write your secrets to. Defaults to `process.env`.
+   * @default process.env
+   */
+  processEnv: NodeJS.ProcessEnv
 }
 
 export interface DotenvConfigOutput {

--- a/tests/modules/dotenv.test.ts
+++ b/tests/modules/dotenv.test.ts
@@ -148,4 +148,28 @@ describe('Dotenv config', () => {
     expect(target.test).toBe(mockParseResponse.test)
     expect(process.env.test).toBeUndefined()
   })
+
+  it('logs the "WAS overwritten" debug message when override is true', () => {
+    process.env.test = 'bar'
+    const log = console.log
+    const messages: string[] = []
+    console.log = (x: unknown) => {
+      messages.push(String(x))
+    }
+    dotenv.config({ path: envPath, debug: true, override: true })
+    console.log = log
+    expect(messages.some((m) => m.includes('"test" is already defined') && m.includes('WAS overwritten'))).toBe(true)
+  })
+
+  it('logs the failure reason when debug is true and the file cannot be read', () => {
+    const log = console.log
+    const messages: string[] = []
+    console.log = (x: unknown) => {
+      messages.push(String(x))
+    }
+    const env = dotenv.config({ path: path.join(__dirname, '../fixtures/.env.does-not-exist'), debug: true })
+    console.log = log
+    expect(env.error).toBeInstanceOf(Error)
+    expect(messages.some((m) => m.startsWith('[dotenv][DEBUG] failed to load'))).toBe(true)
+  })
 })

--- a/tests/modules/dotenv.test.ts
+++ b/tests/modules/dotenv.test.ts
@@ -62,16 +62,26 @@ describe('Dotenv parsing', () => {
 
     expect(payload).toEqual(expectedPayload)
   })
-  it('debug works', () => {
-    const log = console.log
-
-    console.log = (x: unknown) => {
-      expect(x).toBe('[dotenv][DEBUG] did not match key and value when parsing line 1: what is this')
-    }
-
-    dotenv.parse(Buffer.from('what is this'), { debug: true })
-
-    console.log = log
+  it('ignores lines without a key=value pair', () => {
+    const payload = dotenv.parse(Buffer.from('what is this\nKEY=value'))
+    expect(payload).toEqual({ KEY: 'value' })
+  })
+  it('strips inline comments on unquoted values', () => {
+    const payload = dotenv.parse(Buffer.from('FOO=bar # inline comment'))
+    expect(payload.FOO).toBe('bar')
+  })
+  it('supports `export` prefix', () => {
+    const payload = dotenv.parse(Buffer.from('export FOO=bar'))
+    expect(payload.FOO).toBe('bar')
+  })
+  it('supports backtick-quoted values', () => {
+    const payload = dotenv.parse(Buffer.from('FOO=`back"tick\'s`'))
+    expect(payload.FOO).toBe(`back"tick's`)
+  })
+  it('does not pollute Object.prototype via __proto__ key', () => {
+    const payload = dotenv.parse(Buffer.from('__proto__={"polluted":"yes"}\nFOO=bar'))
+    expect(payload.FOO).toBe('bar')
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined()
   })
 })
 
@@ -124,5 +134,18 @@ describe('Dotenv config', () => {
     const env = dotenv.config({ path: envPath, debug: true })
 
     expect(env.parsed?.test).toBe(mockParseResponse.test)
+  })
+
+  it('overrides existing process.env keys when override is true', () => {
+    process.env.test = 'bar'
+    dotenv.config({ path: envPath, override: true })
+    expect(process.env.test).toBe(mockParseResponse.test)
+  })
+
+  it('writes parsed values to a custom processEnv when provided', () => {
+    const target: NodeJS.ProcessEnv = {}
+    dotenv.config({ path: envPath, processEnv: target })
+    expect(target.test).toBe(mockParseResponse.test)
+    expect(process.env.test).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary

Mirror the parser rewrite that upstream `motdotla/dotenv` shipped in v16, in a compact form. Replaces the old line-by-line `^\s*([\w.-]+)\s*=\s*(.*)?\s*$` regex — flagged by CodeQL as a polynomial-time / ReDoS-prone pattern — with the upstream single multiline `LINE` regex.

## Changes

### `packages/dotenv/src/index.ts`
- New `LINE` regex handles `export` prefix, `KEY=` and `KEY:` separators, quoted (`'`, `\"`, `` ` ``) and unquoted values, and trailing inline `#` comments — all in one pass with no catastrophic backtracking.
- Normalize `\r\n?` → `\n` once, then loop with `LINE.exec()`.
- Strip surrounding matching quotes via a single replace; expand `\n` and `\r` escapes only inside double quotes (parity with upstream).
- Added `__proto__` / `constructor` / `prototype` guard so a malicious `.env` cannot pollute the prototype chain (small extra hardening on top of upstream).
- `config()` gained `override` and `processEnv` options, matching upstream's API surface.

### `packages/dotenv/src/types.ts`
- Added `override` and `processEnv` to `DotenvConfigOptions`.
- Marked `DotenvParseOptions.debug` deprecated — the new parser has no concept of an \"unmatched line\" so per-line debug warnings are gone.

### `tests/modules/dotenv.test.ts`
- Replaced the obsolete `debug` test with coverage for the rewrite: ignored non-pair lines, inline comments, `export` prefix, backtick quotes, `__proto__` pollution safety, `override`, and custom `processEnv`.

## Verification

- \`pnpm vitest run tests/modules/dotenv.test.ts\` — 25/25 passing
- Full suite via pre-commit hook — 805 passed, 3 skipped
- \`pnpm --filter @tinyhttp/dotenv build\` — clean

## Notes

Existing behavior is preserved for every case covered by the previous test suite. The \`debug\` option on \`parse()\` is now a no-op but kept for backwards compatibility.