### PR TITLE
test: cover req.stale getter and negotiator empty-param matching

### DIFF
--- a/tests/core/request.test.ts
+++ b/tests/core/request.test.ts
@@ -794,4 +794,25 @@ describe('Request properties', () => {
 
     await fetch('/', { headers: { 'If-None-Match': etag, 'Cache-Control': 'max-age=3600' } }).expectStatus(304)
   })
+  it('req.stale is false when the response is fresh', async () => {
+    const etag = '123'
+    const { fetch } = InitAppAndTest((req, res) => {
+      res.set('ETag', etag)
+      assert.strictEqual(req.fresh, true)
+      assert.strictEqual(req.stale, false)
+      res.end('done')
+    })
+
+    await fetch('/', { headers: { 'If-None-Match': etag, 'Cache-Control': 'max-age=3600' } }).expectStatus(200)
+  })
+  it('req.stale is true when the response is stale', async () => {
+    const { fetch } = InitAppAndTest((req, res) => {
+      res.set('ETag', '123')
+      assert.strictEqual(req.fresh, false)
+      assert.strictEqual(req.stale, true)
+      res.end('done')
+    })
+
+    await fetch('/', { headers: { 'If-None-Match': '456', 'Cache-Control': 'max-age=3600' } }).expectStatus(200)
+  })
 })

--- a/tests/modules/negotiator.test.ts
+++ b/tests/modules/negotiator.test.ts
@@ -282,6 +282,11 @@ describe('Negotiator', () => {
       const negotiator = new Negotiator(createRequest({ accept: 'text/html;level' }))
       expect(negotiator.mediaTypes()).toEqual(['text/html'])
     })
+
+    it('should match provided type when accept has an empty-valued parameter', () => {
+      const negotiator = new Negotiator(createRequest({ accept: 'text/html;level' }))
+      expect(negotiator.mediaTypes(['text/html'])).toEqual(['text/html'])
+    })
   })
 
   describe('edge cases', () => {


### PR DESCRIPTION
## Summary
The suite already covers ~99.7% of packages/*/src, so this fills the few genuinely
reachable gaps rather than chasing dead code.

- req.stale getter (packages/app/src/extend.ts): the defineProperty getter was never
  read by any test. tests/core/request.test.ts now reads req.fresh/req.stale in the
  handler for a fresh and a stale request. Brings function coverage to 100%.
- negotiator empty-valued Accept param (packages/accepts/src/negotiator.ts): covers the
  (spec.params[k] || '') / (p.params[k] || '') fallback for `text/html;level` matched
  against a provided type lacking that param. Added to tests/modules/negotiator.test.ts.

Tests only (+26 lines, 2 files). Result: 824 passed | 3 skipped; statements 99.73%->99.80%,
functions 99.64%->100%. Remaining uncovered lines are unreachable defensive branches.