### PR TITLE
test: cover remaining app and negotiator paths

### DIFF
--- a/tests/core/app.test.ts
+++ b/tests/core/app.test.ts
@@ -3,9 +3,10 @@ import http from 'node:http'
 import { join } from 'node:path'
 import { renderFile } from 'eta'
 import { makeFetch } from 'supertest-fetch'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { App, type Request, type Response } from '../../packages/app/src/index'
 import { View } from '../../packages/app/src/view'
+import * as req from '../../packages/req/src'
 import type { RouterMethod } from '../../packages/router/src'
 import { InitAppAndTest } from '../../test_helpers/initAppAndTest'
 
@@ -51,6 +52,23 @@ describe('Testing App', () => {
     const fetch = makeFetch(server)
 
     await fetch('/').expect(500, 'Ouch, you hurt me on / page.')
+  })
+  it('Custom onError handles unexpected route parameter errors', async () => {
+    const error = new Error('Unable to parse route parameters')
+    const getURLParams = vi.spyOn(req, 'getURLParams').mockImplementationOnce(() => {
+      throw error
+    })
+    const app = new App({
+      onError: (err, _req, res) => res.status(500).end((err as Error).message)
+    })
+
+    app.get('/:id', (_req, res) => res.end('matched'))
+
+    try {
+      await makeFetch(app.listen())('/value').expect(500, error.message)
+    } finally {
+      getURLParams.mockRestore()
+    }
   })
 
   it('App works with HTTP 1.1', async () => {

--- a/tests/core/request.test.ts
+++ b/tests/core/request.test.ts
@@ -794,4 +794,11 @@ describe('Request properties', () => {
 
     await fetch('/', { headers: { 'If-None-Match': etag, 'Cache-Control': 'max-age=3600' } }).expectStatus(304)
   })
+  it('req.stale returns the inverse of req.fresh', async () => {
+    const { fetch } = InitAppAndTest((req, res) => {
+      res.json({ fresh: req.fresh, stale: req.stale })
+    })
+
+    await fetch('/').expect(200, { fresh: false, stale: true })
+  })
 })

--- a/tests/modules/negotiator.test.ts
+++ b/tests/modules/negotiator.test.ts
@@ -282,6 +282,11 @@ describe('Negotiator', () => {
       const negotiator = new Negotiator(createRequest({ accept: 'text/html;level' }))
       expect(negotiator.mediaTypes()).toEqual(['text/html'])
     })
+
+    it('should match parameters without values', () => {
+      const negotiator = new Negotiator(createRequest({ accept: 'text/html;level' }))
+      expect(negotiator.mediaTypes(['text/html;level'])).toEqual(['text/html;level'])
+    })
   })
 
   describe('edge cases', () => {


### PR DESCRIPTION
## Summary
Add focused coverage for three previously untested paths:

- route-parameter failures other than `URIError` reach the configured `onError`
- `req.stale` evaluates as the inverse of `req.fresh`
- media type parameters with omitted values negotiate correctly

## Verification
- `pnpm build`
- `pnpm check`
- `pnpm test` — 824 passed, 3 skipped

Coverage: 99.85% lines, 100% functions, 99.41% branches.