### PR TITLE
ci: restore git tags and GitHub releases in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-tags: true
 
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "chgset:run": "changeset",
     "chgset:version": "changeset version && pnpm install && biome check . --write",
     "chgset": "pnpm chgset:run && pnpm chgset:version",
-    "release": "pnpm -r publish --access public --provenance --no-git-checks",
+    "release": "pnpm -r publish --access public --provenance --no-git-checks && changeset tag",
     "test:dev": "vitest --dir tests",
     "test:coverage": "vitest run --dir tests --coverage",
     "test": "pnpm test:coverage",


### PR DESCRIPTION
## Problem

Since 8dfec433 switched publishing from `changeset publish` to `pnpm -r publish`, releases stopped creating git tags and GitHub releases (last working release: April 15). Yesterday's release published 9 packages to npm but created no tags or GitHub releases.

**Root cause:** changesets/action detects published packages by grepping the publish script's stdout for `New tag: <pkg>@<version>` lines, which only the changesets CLI prints. `pnpm -r publish` emits no such lines, so the action saw zero published packages and skipped `pushTag()` / `createRelease()` entirely. This affects every version of the action (v1 greps stdout, v2 reads a `CHANGESETS_OUTPUT` ndjson file — both signals come only from `changeset publish`), so bumping the action wouldn't fix it.

Reverting to `changeset publish` is not an option since packages use `workspace:` protocol, which only pnpm rewrites at publish time.

## Fix

- Append `changeset tag` to the release script — creates the git tags and prints the `New tag:` lines the action greps for, after pnpm publishes
- Add `fetch-tags: true` to checkout so `changeset tag` only tags untagged versions instead of re-tagging every package at HEAD (which would conflict with existing remote tags)

## Verification

Dry-ran `changeset tag` locally against current master: it tags exactly the 8 packages published without tags (`accepts@2.3.1`, `app@3.0.8`, `dotenv@4.0.0`, `jsonp@2.1.24`, `rate-limit@2.1.9`, `req@2.2.9`, `res@2.2.12`, `type-is@2.2.6`), correctly skips already-tagged `send@2.2.6`, and its output matches the action's regex for all 8.

Side effect: the next release run will retroactively create the missing tags + GitHub releases for those 8 packages (assuming their versions haven't bumped again by then).