### PR TITLE
fix(res): encode authority backslash to prevent open redirect (GHSA-8q4p-mhxr-fq83)

### DIFF
--- a/.changeset/curvy-redirects-hide.md
+++ b/.changeset/curvy-redirects-hide.md
@@ -1,0 +1,6 @@
+---
+"@tinyhttp/res": patch
+"@tinyhttp/app": patch
+---
+
+fix open redirect via a backslash in the authority of `res.redirect()` / `res.location()` (GHSA-8q4p-mhxr-fq83). A URL such as `https://evil.com\@trusted.com` was written to the `Location` header with the backslash raw; some URL parsers resolve that to the host `evil.com`, bypassing redirect allowlists. The backslash is now encoded to `%5C`, matching Express, while the real host is still left verbatim.

--- a/packages/res/src/headers.ts
+++ b/packages/res/src/headers.ts
@@ -35,9 +35,14 @@ export const setLocationHeader =
     // "back" is an alias for the referrer
     if (url === 'back') loc = (getRequestHeader(req)('Referrer') as string) || '/'
     const match = schemeAndHostRegExp.exec(loc)
-    const pos = match ? match[0].length + 1 : 0
-    // Only encode after the host to avoid turning authority backslashes into
-    // encoded bytes that can bypass redirect allowlists.
+    // Encode everything after the scheme + authority. The `schemeAndHostRegExp`
+    // match stops at the first `\`, `/`, `?` or `#`, so any of those delimiters
+    // (including a backslash smuggled into the authority) falls into the encoded
+    // portion. This prevents an open redirect via a raw backslash such as
+    // `https://evil.com\@trusted.com`, which some URL parsers resolve to
+    // `evil.com` (GHSA-8q4p-mhxr-fq83), while leaving the real host verbatim so
+    // redirect allowlists still see it.
+    const pos = match ? match[0].length : 0
     res.setHeader('Location', loc.slice(0, pos) + encodeUrl(loc.slice(pos)))
     return res
   }

--- a/tests/modules/res.test.ts
+++ b/tests/modules/res.test.ts
@@ -141,6 +141,17 @@ describe('Response extensions', () => {
         }
       }).expect(302, `<p>Found. Redirecting to ${encodedXss}</p>`)
     })
+    it('should not allow an open redirect via an authority backslash (GHSA-8q4p-mhxr-fq83)', async () => {
+      const app = runServer((req, res) => {
+        redirect(req, res, () => {})('https://evil.com\\@trusted.com').end()
+      })
+
+      await makeFetch(app)('/', {
+        redirect: 'manual'
+      })
+        .expectStatus(302)
+        .expectHeader('Location', 'https://evil.com%5C@trusted.com')
+    })
     it('should send an empty response for unsupported MIME types', async () => {
       const app = runServer((req, res) => {
         redirect(req, res, (err) => res.writeHead(err.status).end(err.message))('/abc').end()
@@ -527,12 +538,24 @@ describe('Response extensions', () => {
 
       await makeFetch(app)('/').expectHeader('Location', 'https://google.com?q=%A710').expectStatus(200)
     })
-    it('should not encode backslashes in the authority', async () => {
+    // GHSA-8q4p-mhxr-fq83: a backslash right after the host must be encoded to
+    // %5C. Left raw, parsers that treat `\` like `/` resolve
+    // `http://google.com\@apple.com` to host `google.com`, but a redirect
+    // allowlist checking the string sees "google.com..." while the browser may
+    // navigate to `apple.com` — an open redirect.
+    it('should encode a backslash smuggled into the authority', async () => {
       const app = runServer((req, res) => {
         setLocationHeader(req, res)('http://google.com\\@apple.com').end()
       })
 
-      await makeFetch(app)('/').expectHeader('Location', 'http://google.com\\@apple.com').expectStatus(200)
+      await makeFetch(app)('/').expectHeader('Location', 'http://google.com%5C@apple.com').expectStatus(200)
+    })
+    it('should encode an authority backslash in a scheme-relative URL', async () => {
+      const app = runServer((req, res) => {
+        setLocationHeader(req, res)('//google.com\\@apple.com').end()
+      })
+
+      await makeFetch(app)('/').expectHeader('Location', '//google.com%5C@apple.com').expectStatus(200)
     })
     it('should encode backslashes in the path after the authority', async () => {
       const app = runServer((req, res) => {
@@ -541,12 +564,12 @@ describe('Response extensions', () => {
 
       await makeFetch(app)('/').expectHeader('Location', 'https://google.com/foo%5Cbar%5Cbaz').expectStatus(200)
     })
-    it('should preserve the host when an authority backslash is followed by a path', async () => {
+    it('should encode every backslash when the authority is followed by more', async () => {
       const app = runServer((req, res) => {
         setLocationHeader(req, res)('https://google.com\\@app\\l\\e.com').end()
       })
 
-      await makeFetch(app)('/').expectHeader('Location', 'https://google.com\\@app%5Cl%5Ce.com').expectStatus(200)
+      await makeFetch(app)('/').expectHeader('Location', 'https://google.com%5C@app%5Cl%5Ce.com').expectStatus(200)
     })
     it('should encode characters in the fragment', async () => {
       const app = runServer((req, res) => {


### PR DESCRIPTION
## Summary

Fixes **GHSA-8q4p-mhxr-fq83** — an open redirect in `res.redirect()` / `res.location()` (`@tinyhttp/res`).

`setLocationHeader` splits the `Location` value into an unencoded `scheme + authority` head and an `encodeUrl`'d tail, but used `pos = match[0].length + 1`. That `+ 1` pushed the delimiter right after the host — a backslash in `https://evil.com\@trusted.com` — into the **unencoded** head, so it was emitted raw:

```
Location: https://evil.com\@trusted.com
```

Parsers that treat `\` like `/` (per WHATWG URL, and older browsers) resolve that authority to host `evil.com`. A redirect allowlist that string-checks the value sees `evil.com...` while the browser navigates to the attacker's host. Express encodes the backslash to `%5C`; tinyhttp did not.

## Fix

Drop the `+ 1` so the split point is exactly the end of the authority. The `schemeAndHostRegExp` match already stops at the first `\`, `/`, `?` or `#`, so any such delimiter now falls into the `encodeUrl` portion — an authority backslash becomes `%5C` — while the real host is still left verbatim so allowlist checks keep working.

```diff
-    const pos = match ? match[0].length + 1 : 0
+    const pos = match ? match[0].length : 0
```

## Behavior (verified live)

| Input | Before | After |
|---|---|---|
| `https://evil.com\@trusted.com` | `...evil.com\@trusted.com` (raw) | `...evil.com%5C@trusted.com` |
| `//evil.com\@trusted.com` (scheme-relative) | raw | `//evil.com%5C@...` |
| `https://good.com/path?x=1` | unchanged | unchanged |
| `/dashboard` (relative) | unchanged | unchanged |

Confirmed against a live server through both `res.redirect()` and `res.location()`.

## Affected versions

Introduced in **`@tinyhttp/res@2.2.11`** (commit `dd51147`, "harden redirect location handling") and still present in `2.2.12`. `2.2.10` and earlier encoded the entire URL (`encodeUrl(loc)`) and were **not** affected. The advisory listing only `2.2.11` is slightly off — `2.2.12` (and `@tinyhttp/app@3.0.8`) are also vulnerable.

## Tests

Two existing tests had pinned the vulnerable raw-backslash output — updated to expect `%5C`. Added regression coverage for the scheme-relative variant and the `res.redirect()` entry point (the advisory PoC). Full suite: **832 passed / 3 skipped**, lint clean. Changeset included (patch bump for `@tinyhttp/res` + `@tinyhttp/app`).
