### PR TITLE
fix: bump header-range-parser to v2

### DIFF
--- a/.changeset/header-range-parser-v2.md
+++ b/.changeset/header-range-parser-v2.md
@@ -1,0 +1,11 @@
+---
+"@tinyhttp/req": patch
+"@tinyhttp/send": patch
+---
+
+Bump `header-range-parser` from 1.1.4 to 2.0.0.
+
+- Fixes broken TypeScript declarations shipped with v1.x ([r37r0m0d3l/header-range-parser#429](https://github.com/r37r0m0d3l/header-range-parser/issues/429))
+- Malformed `Range` headers (e.g. `bytes=abc-def`) are now classified as syntactically invalid per RFC 9110 and ignored, so `sendFile` serves a 200 full-body response instead of 416. Unsatisfiable and inverted ranges (e.g. `bytes=10-5`) still respond with 416.
+- `req.range()` now returns `-2` (invalid) instead of `-1` (unsatisfiable) for such headers.
+- header-range-parser v2 is ESM-only and declares `engines.node: >=20.19.0`. The shipped code is ES2015-compatible and keeps working on older Node versions via `import`, but package managers may emit engine warnings on Node < 20.19.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: ^0.1.4
       version: 0.1.4
     header-range-parser:
-      specifier: 1.1.4
-      version: 1.1.4
+      specifier: 2.0.0
+      version: 2.0.0
     mrmime:
       specifier: ^2.0.1
       version: 2.0.1
@@ -49,7 +49,7 @@ importers:
         version: 2.2.0
       header-range-parser:
         specifier: 'catalog:'
-        version: 1.1.4
+        version: 2.0.0
       husky:
         specifier: 9.1.7
         version: 9.1.7
@@ -141,7 +141,7 @@ importers:
         version: link:../url
       header-range-parser:
         specifier: 'catalog:'
-        version: 1.1.4
+        version: 2.0.0
 
   packages/res:
     dependencies:
@@ -186,7 +186,7 @@ importers:
         version: link:../etag
       header-range-parser:
         specifier: 'catalog:'
-        version: 1.1.4
+        version: 2.0.0
       mrmime:
         specifier: 'catalog:'
         version: 2.0.1
@@ -948,9 +948,9 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
-  header-range-parser@1.1.4:
-    resolution: {integrity: sha512-KeYnaTStX0a4rkl2L8ow5hQXzg6OI74bmaYJxpaEHUPJWaf41RcgVbDe/UWmh7TbxfXx/FzA1pmwO8Rw91LR+Q==}
-    engines: {node: '>=12.22.0'}
+  header-range-parser@2.0.0:
+    resolution: {integrity: sha512-DMbQU7Dd2tG4a+9M09ZUkPX4Ie/QRed6TYvoeDtgIajIkVo7A7xRTbs/M/j7jFMZzVhe6tVNWLk3/nwPO8iSMQ==}
+    engines: {node: '>=20.19.0'}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -2355,7 +2355,7 @@ snapshots:
 
   has-flag@4.0.0: {}
 
-  header-range-parser@1.1.4: {}
+  header-range-parser@2.0.0: {}
 
   html-escaper@2.0.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ packages:
 
 catalog:
   "@tinyhttp/content-type": ^0.1.4
-  header-range-parser: 1.1.4
+  header-range-parser: 2.0.0
   mrmime: ^2.0.1
   regexparam: ^3.0.0
 

--- a/tests/modules/send.test.ts
+++ b/tests/modules/send.test.ts
@@ -358,15 +358,19 @@ describe('sendFile(path)', () => {
       .expectStatus(416)
       .expectHeader('Content-Range', 'bytes */11')
   })
-  it('should send 416 for a malformed Range header', async () => {
+  it('should serve the full body (200) for a malformed Range header', async () => {
     const app = runServer((req, res) => sendFile(req, res)(testFilePath))
+    // header-range-parser v2 classifies `bytes=abc-def` as syntactically
+    // invalid (-2) rather than unsatisfiable (-1), so per RFC 9110 the header
+    // is ignored and the whole file is served instead of a 416.
     await makeFetch(app)('/', {
       headers: {
         Range: 'bytes=abc-def'
       }
     })
-      .expectStatus(416)
-      .expectHeader('Content-Range', 'bytes */11')
+      .expectStatus(200)
+      .expect('Content-Length', '11')
+      .expect('Hello World')
   })
   it('should serve the full body (200) for a syntactically invalid Range header', async () => {
     const app = runServer((req, res) => sendFile(req, res)(testFilePath))


### PR DESCRIPTION
## What

Bumps `header-range-parser` from `1.1.4` to `2.0.0` (a one-line change in the `pnpm-workspace.yaml` catalog), affecting `@tinyhttp/req` and `@tinyhttp/send`. Includes a changeset (patch for both).

## Why

- **Fixes broken TypeScript declarations** shipped with v1.x ([r37r0m0d3l/header-range-parser#429](https://github.com/r37r0m0d3l/header-range-parser/issues/429)) — v1.1.5's `.d.ts` referenced a non-existent `header-range-parser/src/index` module with CJS-style `export =` contradicting the ESM runtime.
- **RFC 9110 compliance**: malformed `Range` headers (e.g. `bytes=abc-def`) are now classified as syntactically invalid (`-2`) instead of unsatisfiable (`-1`), so they are ignored and `sendFile` serves a 200 full-body response instead of 416. Unsatisfiable/inverted ranges (e.g. `bytes=10-5`, GHSA-w65r-fqv6-q6w9) still respond with 416 — verified by tests.
- `req.range()` now returns `-2` instead of `-1` for such inputs.

## Not a breaking change

v2 is ESM-only and declares `engines.node: >=20.19.0`, but:

- The shipped code is plain **ES2015** (verified: no syntax/APIs past ES2015) and runs on Node 14/16 via `import`.
- The `>=20.19.0` floor only guards `require(esm)` for CJS consumers — a scenario that cannot arise through tinyhttp, since `@tinyhttp/req`/`send` are themselves ESM-only and import it with `import`.
- Engines on `req`/`send` intentionally stay at `>=14.13.1`. Consumers on Node < 20.19 (EOL runtimes) may see an `EBADENGINE` warning from npm (or need `--ignore-engines` with yarn); runtime behavior is unaffected.

## Test change

`tests/modules/send.test.ts`: the malformed-Range test now expects 200 full-body (matching the pre-existing `invalid-range` test's documented `-2` → ignore behavior).

## Verification

- `pnpm install` — passes supply-chain policies, only 2.0.0 in lockfile
- `pnpm build` — all packages compile
- `pnpm test` — 832 passed, 3 skipped (22 files)