### PR TITLE
fix: add TypeScript overload signatures for accepts methods

### DIFF
--- a/packages/app/src/extend.ts
+++ b/packages/app/src/extend.ts
@@ -78,10 +78,10 @@ export const extendMiddleware = <EngineOptions extends TemplateEngineOptions = T
       if (!acceptsInstance) acceptsInstance = new Accepts(req)
       return acceptsInstance
     }
-    req.accepts = (...types) => getAcceptsInstance().types(types)
-    req.acceptsCharsets = (...charsets) => getAcceptsInstance().charsets(charsets)
-    req.acceptsEncodings = (...encodings) => getAcceptsInstance().encodings(encodings)
-    req.acceptsLanguages = (...languages) => getAcceptsInstance().languages(languages)
+    req.accepts = ((...types: string[]) => getAcceptsInstance().types(types)) as Request['accepts']
+    req.acceptsCharsets = ((...charsets: string[]) => getAcceptsInstance().charsets(charsets)) as Request['acceptsCharsets']
+    req.acceptsEncodings = ((...encodings: string[]) => getAcceptsInstance().encodings(encodings)) as Request['acceptsEncodings']
+    req.acceptsLanguages = ((...languages: string[]) => getAcceptsInstance().languages(languages)) as Request['acceptsLanguages']
 
     req.xhr = checkIfXMLHttpRequest(req)
 

--- a/packages/app/src/extend.ts
+++ b/packages/app/src/extend.ts
@@ -79,9 +79,12 @@ export const extendMiddleware = <EngineOptions extends TemplateEngineOptions = T
       return acceptsInstance
     }
     req.accepts = ((...types: string[]) => getAcceptsInstance().types(types)) as Request['accepts']
-    req.acceptsCharsets = ((...charsets: string[]) => getAcceptsInstance().charsets(charsets)) as Request['acceptsCharsets']
-    req.acceptsEncodings = ((...encodings: string[]) => getAcceptsInstance().encodings(encodings)) as Request['acceptsEncodings']
-    req.acceptsLanguages = ((...languages: string[]) => getAcceptsInstance().languages(languages)) as Request['acceptsLanguages']
+    req.acceptsCharsets = ((...charsets: string[]) =>
+      getAcceptsInstance().charsets(charsets)) as Request['acceptsCharsets']
+    req.acceptsEncodings = ((...encodings: string[]) =>
+      getAcceptsInstance().encodings(encodings)) as Request['acceptsEncodings']
+    req.acceptsLanguages = ((...languages: string[]) =>
+      getAcceptsInstance().languages(languages)) as Request['acceptsLanguages']
 
     req.xhr = checkIfXMLHttpRequest(req)
 

--- a/packages/app/src/request.ts
+++ b/packages/app/src/request.ts
@@ -114,7 +114,7 @@ export type Protocol = 'http' | 'https' | string
 
 export type { URLParams }
 
-type AcceptsReturns = string | boolean | string[]
+type AcceptsReturns = string | false | string[]
 
 export interface Request extends IncomingMessage {
   originalUrl: string
@@ -136,10 +136,30 @@ export interface Request extends IncomingMessage {
   subdomains?: string[]
   get: <HeaderName extends string>(header: HeaderName) => IncomingHttpHeaders[HeaderName]
   range: (size: number, options?: RangeParserOptions) => -1 | -2 | -3 | RangeParserRanges | undefined
-  accepts: (...types: string[]) => AcceptsReturns
-  acceptsEncodings: (...encodings: string[]) => AcceptsReturns
-  acceptsCharsets: (...charsets: string[]) => AcceptsReturns
-  acceptsLanguages: (...languages: string[]) => AcceptsReturns
+  accepts: {
+    (): string[]
+    (type: string): string | false
+    (types: string[]): string | false
+    (...types: string[]): string | false
+  }
+  acceptsEncodings: {
+    (): string[]
+    (encoding: string): string | false
+    (encodings: string[]): string | false
+    (...encodings: string[]): string | false
+  }
+  acceptsCharsets: {
+    (): string[]
+    (charset: string): string | false
+    (charsets: string[]): string | false
+    (...charsets: string[]): string | false
+  }
+  acceptsLanguages: {
+    (): string[]
+    (language: string): string | false
+    (languages: string[]): string | false
+    (...languages: string[]): string | false
+  }
   is: (...types: string[]) => string | boolean
   cookies?: any
   signedCookies?: any

--- a/packages/app/src/request.ts
+++ b/packages/app/src/request.ts
@@ -114,8 +114,6 @@ export type Protocol = 'http' | 'https' | string
 
 export type { URLParams }
 
-type AcceptsReturns = string | false | string[]
-
 export interface Request extends IncomingMessage {
   originalUrl: string
   path: string


### PR DESCRIPTION
## Problem

The `Request` interface defines `accepts`, `acceptsEncodings`, `acceptsCharsets`, and `acceptsLanguages` with a single signature:

```typescript
accepts: (...types: string[]) => string | boolean | string[]
```

This means TypeScript can't narrow the return type based on usage. Users must cast or type-guard every call:

```typescript
const type = req.accepts('json', 'html'); // string | boolean | string[]
const all = req.accepts(); // string | boolean | string[] (should be string[])
```

## Solution

Add TypeScript overload signatures that narrow the return type, matching Express's type definitions. No runtime changes.

Closes #396

Co-authored-by: claygeo <200541338+claygeo@users.noreply.github.com>