### PR TITLE
fix: sanitize default error handler output (GHSA-rqg5-h5qr-gp89)

### DIFF
--- a/.changeset/fix-xss-on-error-handler.md
+++ b/.changeset/fix-xss-on-error-handler.md
@@ -1,0 +1,19 @@
+---
+"@tinyhttp/app": patch
+"@tinyhttp/res": patch
+---
+
+fix: sanitize default error handler output (GHSA-rqg5-h5qr-gp89)
+
+The default `onErrorHandler` reflected attacker-influenced error content
+(route params, query strings, cookies, etc.) byte-for-byte into the response
+body with no escaping and no `Content-Type`, which browsers could MIME-sniff
+as HTML and execute (reflected XSS).
+
+- Escape all reflected error content using the existing `escapeHTML` helper.
+- Always set `Content-Type: text/plain; charset=utf-8` and
+  `X-Content-Type-Options: nosniff` on error responses.
+- Suppress raw error details when `NODE_ENV === 'production'`.
+
+`escapeHTML` is now exported from `@tinyhttp/res` so it can be reused
+framework-wide.

--- a/packages/app/src/onError.ts
+++ b/packages/app/src/onError.ts
@@ -1,4 +1,6 @@
+import { Buffer } from 'node:buffer'
 import { STATUS_CODES } from 'node:http'
+import { escapeHTML } from '@tinyhttp/res'
 import type { NextFunction } from '@tinyhttp/router'
 import type { App } from './app.js'
 import type { Request } from './request.js'
@@ -20,8 +22,34 @@ export const onErrorHandler: ErrorHandler = function (this: App, err: any, _req:
   }
 
   const code = err.code in STATUS_CODES ? err.code : err.status
+  const isProd = process.env.NODE_ENV === 'production'
 
-  if (typeof err === 'string' || Buffer.isBuffer(err)) res.writeHead(500).end(err)
-  else if (code in STATUS_CODES) res.writeHead(code).end(STATUS_CODES[code])
-  else res.writeHead(500).end(err.message)
+  // GHSA-rqg5-h5qr-gp89: always serve error bodies as plain text, refuse
+  // MIME-sniffing, and escape any request-influenced content so it cannot be
+  // reflected as HTML.
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8')
+  res.setHeader('X-Content-Type-Options', 'nosniff')
+
+  if (code in STATUS_CODES) {
+    res.writeHead(code).end(STATUS_CODES[code])
+    return
+  }
+
+  // Don't leak internal error details in production.
+  if (isProd) {
+    res.writeHead(500).end(STATUS_CODES[500])
+    return
+  }
+
+  if (typeof err === 'string') {
+    res.writeHead(500).end(escapeHTML(err))
+    return
+  }
+
+  if (Buffer.isBuffer(err)) {
+    res.writeHead(500).end(escapeHTML(err.toString()))
+    return
+  }
+
+  res.writeHead(500).end(escapeHTML(String(err?.message ?? err)))
 }

--- a/packages/res/src/index.ts
+++ b/packages/res/src/index.ts
@@ -13,3 +13,4 @@ export {
   setVaryHeader
 } from './headers.js'
 export { redirect } from './redirect.js'
+export { escapeHTML } from './util.js'

--- a/tests/core/app.test.ts
+++ b/tests/core/app.test.ts
@@ -290,6 +290,58 @@ describe('Testing App routing', () => {
       await makeFetch(server)('/').expect(500, 'bruh')
     })
   })
+  describe('default onError handler sanitizes error output (GHSA-rqg5-h5qr-gp89)', () => {
+    it('escapes HTML reflected via next(string)', async () => {
+      const app = new App()
+
+      app.use((_req, _res, next) => next('<script>alert(1)</script>'))
+
+      await makeFetch(app.listen())('/').expect(500, '&lt;script&gt;alert(1)&lt;/script&gt;')
+    })
+    it('escapes HTML in Error.message', async () => {
+      const app = new App()
+
+      app.use(() => {
+        throw new Error('Invalid search query: <script>alert(document.cookie)</script>')
+      })
+
+      await makeFetch(app.listen())('/').expect(
+        500,
+        'Invalid search query: &lt;script&gt;alert(document.cookie)&lt;/script&gt;'
+      )
+    })
+    it('escapes HTML in Buffer errors', async () => {
+      const app = new App()
+
+      app.use((_req, _res, next) => next(Buffer.from('<script>alert(1)</script>')))
+
+      await makeFetch(app.listen())('/').expect(500, '&lt;script&gt;alert(1)&lt;/script&gt;')
+    })
+    it('sets Content-Type text/plain and X-Content-Type-Options nosniff', async () => {
+      const app = new App()
+
+      app.use((_req, _res, next) => next('oops'))
+
+      await makeFetch(app.listen())('/')
+        .expect(500, 'oops')
+        .expect('Content-Type', 'text/plain; charset=utf-8')
+        .expect('X-Content-Type-Options', 'nosniff')
+    })
+    it('suppresses raw error details when NODE_ENV is production', async () => {
+      const prev = process.env.NODE_ENV
+      process.env.NODE_ENV = 'production'
+
+      try {
+        const app = new App()
+
+        app.use((_req, _res, next) => next('sensitive <script>alert(1)</script> details'))
+
+        await makeFetch(app.listen())('/').expect(500, 'Internal Server Error')
+      } finally {
+        process.env.NODE_ENV = prev
+      }
+    })
+  })
 })
 
 describe('App methods', () => {


### PR DESCRIPTION
## Summary

Fixes **GHSA-rqg5-h5qr-gp89** (reflected XSS in `@tinyhttp/app`'s default error handler, `<= 3.0.10`).

The default `onErrorHandler` wrote attacker-influenced error content (route params, query strings, cookies, etc.) byte-for-byte into the response body — with no escaping, no `Content-Type`, and no `X-Content-Type-Options: nosniff`. Since browsers MIME-sniff responses that lack a `Content-Type`, a body beginning with `<script>` (e.g. `next(req.query.x)`) executes as HTML.

## Changes

- **`packages/app/src/onError.ts`** — escape all reflected error content via the existing `escapeHTML` helper; always set `Content-Type: text/plain; charset=utf-8` and `X-Content-Type-Options: nosniff`; suppress raw error details when `NODE_ENV === 'production'`. Status-code errors (404/400) still return safe `STATUS_CODES` text; parent-onError delegation and `headersSent → destroy` behavior preserved.
- **`packages/res/src/index.ts`** — publicly export `escapeHTML` (was only exported from internal `util.ts`, so the advisory's suggested import would not have resolved).
- **`tests/core/app.test.ts`** — 4 new tests: escaped `next(string)`, escaped `Error.message`, header assertions (`Content-Type`, `X-Content-Type-Options`), and production suppression.
- **`.changeset/fix-xss-on-error-handler.md`** — patch changeset for `@tinyhttp/app` + `@tinyhttp/res`.

## Verification

- `pnpm check` — no errors (only pre-existing warnings)
- `pnpm test` — 836 passed
- `pnpm build` — exit 0

## Note on severity

The advisory's vector `CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N` computes to **5.6**, not the stated **6.1** (the rating "Medium" is unchanged either way). Worth correcting in the advisory.